### PR TITLE
fix drawer on left position

### DIFF
--- a/ionic.contrib.drawer.js
+++ b/ionic.contrib.drawer.js
@@ -129,7 +129,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
         }
       }
     } else {
-      newX = Math.min(0, (-width + (lastX - offsetX)));
+      newX = Math.min(0, ((self.opened ? 0 : -width) + (lastX - offsetX)));
       
       if (Math.abs(startDragX - lastX) > thresholdX) {
         $ionicScrollDelegate.freezeAllScrolls(true);


### PR DESCRIPTION
When you click on opened drawer on left position, it 'closes' automatically - moves behind left area.
